### PR TITLE
Authenticate without SSH key for clone & backup wikis

### DIFF
--- a/backup_github_repositories.ps1
+++ b/backup_github_repositories.ps1
@@ -184,7 +184,21 @@ ForEach ($repository in $repositories) {
 
                 [Parameter(Mandatory=$true)]
                 [String]
-                $directory
+                $directory,
+                
+                [Parameter(
+                    Mandatory=$True,
+                    HelpMessage="The name of a GitHub user that has access to the GitHub API."
+                )]
+                [String]
+                $cloneUserName,
+                
+                [Parameter(
+                    Mandatory=$True,
+                    HelpMessage="The name of a GitHub user that has access to the GitHub API."
+                )]
+                [String]
+                $cloneUserSecret
             )
 
             if (Test-Path "${directory}") {
@@ -195,7 +209,8 @@ ForEach ($repository in $repositories) {
                 return
             }
 
-            git clone --quiet --mirror "git@github.com:${fullName}.git" "${directory}"
+            Write-Host "git clone --quiet --mirror https://${cloneUserName}:${cloneUserSecret}@github.com/${fullName}.git"
+            git clone --quiet --mirror "https://${cloneUserName}:${cloneUserSecret}@github.com/${fullName}.git" "${directory}"
             Write-Host "[${fullName}] Backup completed with git clone strategy."
         }
 
@@ -203,7 +218,8 @@ ForEach ($repository in $repositories) {
         $directory = $(Join-Path -Path $backupDirectory -ChildPath "$($repository.name).git")
 
         Write-Host "[$($repository.full_name)] Starting backup to ${directory}..." -ForegroundColor "DarkYellow"
-        Start-Job $scriptBlock -ArgumentList $repository.full_name, $directory | Out-Null
+        Start-Job $scriptBlock -ArgumentList $repository.full_name, $directory, $userName, $userSecret | Out-Null
+        
 
         # Give the job some time to start.
         $warmUpTimeoutInMilliseconds = 50

--- a/backup_github_repositories.ps1
+++ b/backup_github_repositories.ps1
@@ -209,7 +209,6 @@ ForEach ($repository in $repositories) {
                 return
             }
 
-            Write-Host "git clone --quiet --mirror https://${cloneUserName}:${cloneUserSecret}@github.com/${fullName}.git"
             git clone --quiet --mirror "https://${cloneUserName}:${cloneUserSecret}@github.com/${fullName}.git" "${directory}"
             Write-Host "[${fullName}] Backup completed with git clone strategy."
         }

--- a/backup_github_repositories.ps1
+++ b/backup_github_repositories.ps1
@@ -141,7 +141,7 @@ Do {
     $paginatedGitHubApiUri = "${gitHubRepositoriesUrl}&page=${pageNumber}"
 
     Write-Host "Requesting '${paginatedGitHubApiUri}'..." -ForegroundColor "Yellow"
-    $paginatedRepositories = Invoke-WebRequest -Uri $paginatedGitHubApiUri -Headers $requestHeaders | `
+    $paginatedRepositories = Invoke-WebRequest -Uri $paginatedGitHubApiUri -Headers $requestHeaders -UseBasicParsing | `
                              Select-Object -ExpandProperty Content | `
                              ConvertFrom-Json
 

--- a/backup_github_repositories.ps1
+++ b/backup_github_repositories.ps1
@@ -220,6 +220,13 @@ ForEach ($repository in $repositories) {
         Write-Host "[$($repository.full_name)] Starting backup to ${directory}..." -ForegroundColor "DarkYellow"
         Start-Job $scriptBlock -ArgumentList $repository.full_name, $directory, $userName, $userSecret | Out-Null
         
+        if ($repository.has_wiki -eq "true") {
+            $wiki_full_name = "$($repository.full_name).wiki"
+            $wiki_directory = $(Join-Path -Path $backupDirectory -ChildPath "$($repository.name).wiki.git")
+            Write-Host "[${wiki_full_name}] Starting wiki backup to ${wiki_directory}..." -ForegroundColor "DarkYellow"
+            #TODO: Wikis are enabled by default on repos, but a wiki may not exist, so an ugly error appears here when no wiki exists, but it's not fatal
+            Start-Job $scriptBlock -ArgumentList $wiki_full_name, $wiki_directory, $userName, $userSecret | Out-Null
+        }
 
         # Give the job some time to start.
         $warmUpTimeoutInMilliseconds = 50


### PR DESCRIPTION
I changed how it authenticates during the clone step to no longer require an SSH key, easier for adding to a task runner since you have to specify a username and password anyway. See line 212

I also added the ability to backup wikis